### PR TITLE
[Fix] duplicated function definition

### DIFF
--- a/src/ecs/task-definition.ts
+++ b/src/ecs/task-definition.ts
@@ -102,30 +102,8 @@ const containerDefinitionFromConfiguration = (params: Params, taskName: string) 
 
   return taskConfig.containerMemory ? {
     ...containerDefinition,
-    memory: taskConfig.containerMemory
+    memory: taskConfig.containerMemory,
   } : containerDefinition
-}
-
-export const taskDefinitionfromConfiguration = (params: Params): RegisterTaskDefinitionCommandInput => {
-  const { taskName, variables, config } = params
-  const { project, environment } = variables
-  const taskConfig = config.tasks[taskName]
-
-  const taskNames = taskConfig.siblingContainers ? [taskName, ...taskConfig.siblingContainers] : [taskName]
-  const containerDefinitions = taskNames.map(name => containerDefinitionFromConfiguration(params, name))
-
-  return {
-    name: taskName,
-    image: taskConfig.image,
-    command: taskConfig.command,
-    portMappings: portMappingsFromConfiguration(taskConfig),
-    environment: environmentFromEnvVars(envVars),
-    secrets: secretsFromConfiguration(taskName, clusterName, config, region),
-    logConfiguration: logConfigurationFromConfiguration(taskName, variables),
-    essential: true,
-    readonlyRootFilesystem: false,
-    dependsOn: taskConfig.dependsOn,
-  }
 }
 
 export const taskDefinitionfromConfiguration = (params: Params): RegisterTaskDefinitionCommandInput => {


### PR DESCRIPTION
Found 2 definitions for the same function `taskDefinitionfromConfiguration`.

It seems it was a merging issue maybe. Checked the file history to see which one of the functions to remove.

@swiknaba or @samkahchiin could you validate that this is the right change?

https://www.loom.com/share/b6b80c1225bf4864bf93fe266abe73d9